### PR TITLE
fix: dprint formatting for insert_text_overwrite

### DIFF
--- a/crates/canvist_wasm/src/lib.rs
+++ b/crates/canvist_wasm/src/lib.rs
@@ -2459,10 +2459,8 @@ impl CanvistEditor {
 		}
 
 		// After delete (if any), cursor should be at `offset`.
-		self.runtime.apply_operation(Operation::insert(
-			Position::new(offset),
-			text.to_string(),
-		));
+		self.runtime
+			.apply_operation(Operation::insert(Position::new(offset), text.to_string()));
 		let _ = self.runtime.handle_event(EditorEvent::SelectionSet {
 			selection: Selection::collapsed(Position::new(offset + insert_len)),
 		});


### PR DESCRIPTION
Fix formatting in `insert_text_overwrite` that caused CI lint failure.