### PR TITLE
feat: rich-text clipboard paste and runtime integration tests

### DIFF
--- a/.changeset/rich-paste-and-tests.md
+++ b/.changeset/rich-paste-and-tests.md
@@ -1,0 +1,22 @@
+---
+"canvist_core": patch
+---
+
+Rich-text clipboard paste and integration tests
+
+### Rich-text paste
+
+The demo's Ctrl+V handler now attempts to read HTML from the clipboard via the
+Clipboard API (`clipboard.read()` with `text/html` MIME type) before falling
+back to plain text. When HTML is available, it's passed to `paste_html()` which
+preserves bold, italic, underline, and strikethrough formatting from the source.
+
+### Integration tests
+
+Added 3 new runtime integration tests:
+- `format_partial_then_undo_preserves_text` — format a substring, undo, verify
+  all runs are unstyled and text is preserved
+- `insert_newline_creates_paragraph_then_undo_merges` — verify paragraph
+  splitting and merging through undo
+- `multiple_operations_undo_redo_roundtrip` — insert → format → insert → undo
+  chain with redo verification

--- a/.pi/scheduler.json
+++ b/.pi/scheduler.json
@@ -2,21 +2,6 @@
   "version": 1,
   "tasks": [
     {
-      "id": "vl0fvc40",
-      "prompt": "continue improving the codebase",
-      "kind": "recurring",
-      "enabled": true,
-      "createdAt": 1774286283770,
-      "nextRunAt": 1774292295125,
-      "intervalMs": 600000,
-      "expiresAt": 1774545483770,
-      "jitterMs": 11355,
-      "runCount": 5,
-      "pending": false,
-      "lastRunAt": 1774292170416,
-      "lastStatus": "success"
-    },
-    {
       "id": "vxxijzm9",
       "prompt": "continue improving the codebae",
       "kind": "recurring",
@@ -27,8 +12,23 @@
       "expiresAt": 1774545477211,
       "jitterMs": 18112,
       "runCount": 4,
-      "pending": false,
+      "pending": true,
       "lastRunAt": 1774291700765,
+      "lastStatus": "success"
+    },
+    {
+      "id": "vl0fvc40",
+      "prompt": "continue improving the codebase",
+      "kind": "recurring",
+      "enabled": true,
+      "createdAt": 1774286283770,
+      "nextRunAt": 1774292895125,
+      "intervalMs": 600000,
+      "expiresAt": 1774545483770,
+      "jitterMs": 11355,
+      "runCount": 6,
+      "pending": false,
+      "lastRunAt": 1774292669194,
       "lastStatus": "success"
     }
   ]

--- a/crates/canvist_core/src/document.rs
+++ b/crates/canvist_core/src/document.rs
@@ -384,7 +384,7 @@ impl Document {
 
 		// Delete text from overlapping runs.
 		let runs_to_delete = self.overlapping_runs(start, end);
-		let mut dirty = !runs_to_delete.is_empty() || crosses_paragraph;
+		let dirty = !runs_to_delete.is_empty() || crosses_paragraph;
 		for (run_id, local_start, local_end) in runs_to_delete {
 			if local_start >= local_end {
 				continue;

--- a/crates/canvist_core/src/runtime.rs
+++ b/crates/canvist_core/src/runtime.rs
@@ -718,4 +718,103 @@ mod tests {
 		assert!(runtime.undo()); // undo "a"
 		assert_eq!(runtime.document().plain_text(), "");
 	}
+
+	#[test]
+	fn format_partial_then_undo_preserves_text() {
+		let mut runtime = runtime_with_plaintext("Hello world");
+		let _ = runtime.handle_event(EditorEvent::SelectionSet {
+			selection: Selection::range(Position::new(0), Position::new(5)),
+		});
+		runtime.apply_operation(crate::operation::Operation::format(
+			Selection::range(Position::new(0), Position::new(5)),
+			crate::Style::new().bold(),
+		));
+
+		// After format: 2 runs ("Hello" bold + " world" normal).
+		let runs = runtime.document().styled_runs();
+		assert_eq!(runs.len(), 2);
+		assert_eq!(runs[0].0, "Hello");
+		assert_eq!(runtime.document().plain_text(), "Hello world");
+
+		// Undo the format.
+		assert!(runtime.undo());
+		assert_eq!(runtime.document().plain_text(), "Hello world");
+
+		// After undo, all runs should be unstyled.
+		for (text, style, _, _) in runtime.document().styled_runs() {
+			assert_eq!(
+				style.font_weight, None,
+				"run '{}' should be unstyled after undo",
+				text
+			);
+		}
+	}
+
+	#[test]
+	fn insert_newline_creates_paragraph_then_undo_merges() {
+		let mut runtime = runtime_with_plaintext("ab");
+		assert_eq!(runtime.document().paragraph_count(), 1);
+
+		// Move cursor to offset 1 and insert newline.
+		let _ = runtime.handle_event(EditorEvent::SelectionSet {
+			selection: Selection::collapsed(Position::new(1)),
+		});
+		let _ = runtime
+			.handle_event(EditorEvent::TextInsert {
+				text: "\n".to_string(),
+			})
+			.unwrap();
+
+		assert_eq!(runtime.document().paragraph_count(), 2);
+		assert_eq!(runtime.document().plain_text(), "a\nb");
+
+		// Undo should merge back to 1 paragraph.
+		assert!(runtime.undo());
+		assert_eq!(runtime.document().paragraph_count(), 1);
+		assert_eq!(runtime.document().plain_text(), "ab");
+	}
+
+	#[test]
+	fn multiple_operations_undo_redo_roundtrip() {
+		let mut runtime = runtime_with_plaintext("");
+
+		// Insert → Format → Insert.
+		runtime
+			.handle_event(EditorEvent::TextInsert {
+				text: "Hello".to_string(),
+			})
+			.unwrap();
+		runtime.apply_operation(crate::operation::Operation::format(
+			Selection::range(Position::new(0), Position::new(5)),
+			crate::Style::new().bold(),
+		));
+		let _ = runtime.handle_event(EditorEvent::SelectionSet {
+			selection: Selection::collapsed(Position::new(5)),
+		});
+		runtime
+			.handle_event(EditorEvent::TextInsert {
+				text: " world".to_string(),
+			})
+			.unwrap();
+
+		assert_eq!(runtime.document().plain_text(), "Hello world");
+
+		// Undo " world".
+		assert!(runtime.undo());
+		assert_eq!(runtime.document().plain_text(), "Hello");
+
+		// Undo format.
+		assert!(runtime.undo());
+		assert_eq!(runtime.document().plain_text(), "Hello");
+
+		// Redo format.
+		assert!(runtime.redo());
+		let runs = runtime.document().styled_runs();
+		assert!(runs.iter().any(|(_, s, _, _)| s.font_weight
+			== Some(crate::style::FontWeight::Bold)));
+
+		// Redo " world".
+		assert!(runtime.redo());
+		assert_eq!(runtime.document().plain_text(), "Hello world");
+	}
 }

--- a/packages/canvist/demo/index.html
+++ b/packages/canvist/demo/index.html
@@ -1423,15 +1423,44 @@
           }
           if (mod && e.key === "v") {
             e.preventDefault();
-            navigator.clipboard.readText().then((text) => {
-              if (text) {
-                deleteSelectionIfNeeded();
-                editor.insert_text_at(cursorOffset, text);
-                cursorOffset += text.length;
-                clearSelection();
-                renderFrame();
+            // Try rich-text paste first via Clipboard API, fall back to plain text.
+            (async () => {
+              try {
+                const items = await navigator.clipboard.read();
+                let htmlPasted = false;
+                for (const item of items) {
+                  if (item.types.includes("text/html")) {
+                    const blob = await item.getType("text/html");
+                    const html = await blob.text();
+                    deleteSelectionIfNeeded();
+                    editor.paste_html(html);
+                    cursorOffset = editor.selection_end();
+                    clearSelection();
+                    htmlPasted = true;
+                    break;
+                  }
+                }
+                if (!htmlPasted) {
+                  const text = await navigator.clipboard.readText();
+                  if (text) {
+                    deleteSelectionIfNeeded();
+                    editor.insert_text_at(cursorOffset, text);
+                    cursorOffset += text.length;
+                    clearSelection();
+                  }
+                }
+              } catch {
+                // Fallback for browsers that don't support clipboard.read().
+                const text = await navigator.clipboard.readText();
+                if (text) {
+                  deleteSelectionIfNeeded();
+                  editor.insert_text_at(cursorOffset, text);
+                  cursorOffset += text.length;
+                  clearSelection();
+                }
               }
-            });
+              renderFrame();
+            })();
             return;
           }
 


### PR DESCRIPTION
## Rich-text Paste

Ctrl+V now reads `text/html` from clipboard first, preserving bold/italic/underline/strikethrough. Falls back to plain text.

## Integration Tests

3 new runtime tests:
- Format partial + undo roundtrip
- Paragraph split/merge via undo
- Insert → format → insert → undo → redo chain

## Tests
- **148/148 pass** (3 new)
- Zero warnings
