### PR TITLE
fix: resolve all 586 TypeScript type errors

### DIFF
--- a/.changeset/fix-typescript-types.md
+++ b/.changeset/fix-typescript-types.md
@@ -1,0 +1,24 @@
+---
+"canvist_core": patch
+---
+
+Fix TypeScript type checking — 586 errors → 0
+
+### Root cause
+
+The `WasmCanvistEditor` interface in `wasm.ts` only declared ~30 of the 568+
+WASM methods. The `editor.ts` wrapper used all 568, causing 586 type errors
+that were masked by `--no-check` builds.
+
+### Fix
+
+- `WasmCanvistEditor` now re-exports the auto-generated type from
+  `wasm/canvist_wasm.d.ts` via `import type`, ensuring all WASM methods are
+  available with correct signatures.
+- Added `diff_texts` static method to `CanvistWasmModule` interface.
+- Fixed `colorRgba` argument type: `number[]` → `Uint8Array`.
+- Added missing `setTextAlign`, `textAlign`, `enableCollab`, `collabEnabled`,
+  `collabEncodeState/Vector`, `collabApplyUpdate`, `collabSyncLocal` to the
+  public editor API object.
+
+`deno check src/editor.ts` now passes with **zero errors**.

--- a/.pi/scheduler.json
+++ b/.pi/scheduler.json
@@ -2,21 +2,6 @@
   "version": 1,
   "tasks": [
     {
-      "id": "vl0fvc40",
-      "prompt": "continue improving the codebase",
-      "kind": "recurring",
-      "enabled": true,
-      "createdAt": 1774286283770,
-      "nextRunAt": 1774295895125,
-      "intervalMs": 600000,
-      "expiresAt": 1774545483770,
-      "jitterMs": 11355,
-      "runCount": 11,
-      "pending": false,
-      "lastRunAt": 1774295588134,
-      "lastStatus": "success"
-    },
-    {
       "id": "vxxijzm9",
       "prompt": "continue improving the codebae",
       "kind": "recurring",
@@ -27,8 +12,23 @@
       "expiresAt": 1774545477211,
       "jitterMs": 18112,
       "runCount": 8,
-      "pending": false,
+      "pending": true,
       "lastRunAt": 1774295319629,
+      "lastStatus": "success"
+    },
+    {
+      "id": "vl0fvc40",
+      "prompt": "continue improving the codebase",
+      "kind": "recurring",
+      "enabled": true,
+      "createdAt": 1774286283770,
+      "nextRunAt": 1774296495125,
+      "intervalMs": 600000,
+      "expiresAt": 1774545483770,
+      "jitterMs": 11355,
+      "runCount": 12,
+      "pending": false,
+      "lastRunAt": 1774295895637,
       "lastStatus": "success"
     }
   ]

--- a/packages/canvist/src/editor.ts
+++ b/packages/canvist/src/editor.ts
@@ -1090,7 +1090,7 @@ export async function createEditor(
 					Boolean(style.underline),
 					style.fontSize,
 					style.fontFamily,
-					style.colorRgba,
+					style.colorRgba ? new Uint8Array(style.colorRgba) : undefined,
 				);
 				renderFrame();
 			},
@@ -3681,6 +3681,35 @@ export async function createEditor(
 				syncTime();
 				ref.remove_highlight_color();
 				renderFrame();
+			},
+
+			// ── Text Alignment ──────────────────────────────────────────
+			setTextAlign(align: string) {
+				ref.set_text_align(align);
+				renderFrame();
+			},
+			get textAlign() {
+				return ref.text_align();
+			},
+
+			// ── Collaboration ───────────────────────────────────────────
+			enableCollab() {
+				ref.enable_collab();
+			},
+			get collabEnabled() {
+				return ref.collab_enabled();
+			},
+			collabEncodeState() {
+				return ref.collab_encode_state();
+			},
+			collabEncodeStateVector() {
+				return ref.collab_encode_state_vector();
+			},
+			collabApplyUpdate(update: Uint8Array) {
+				ref.collab_apply_update(update);
+			},
+			collabSyncLocal() {
+				ref.collab_sync_local();
 			},
 		};
 	}

--- a/packages/canvist/src/wasm.ts
+++ b/packages/canvist/src/wasm.ts
@@ -6,68 +6,24 @@
  * multiple times is safe.
  */
 
+import type { CanvistEditor as GeneratedCanvistEditor } from "../wasm/canvist_wasm.d.ts";
+
 let _initialised = false;
 let _initPromise: Promise<void> | null = null;
 let _wasmModule: CanvistWasmModule | null = null;
 
-export interface WasmCanvistEditor {
-	canvas_id(): string;
-	plain_text(): string;
-	char_count(): number;
-	insert_text(text: string): void;
-	insert_text_at(offset: number, text: string): void;
-	delete_range(start: number, end: number): void;
-	set_title(title: string): void;
-	to_json(): string;
-	queue_text_input(text: string): void;
-	queue_key_down(key: string): void;
-	queue_key_down_with_modifiers(
-		key: string,
-		shift: boolean,
-		control: boolean,
-		alt: boolean,
-		meta: boolean,
-		repeat: boolean,
-	): void;
-	process_events(): void;
-	selection_start(): number;
-	selection_end(): number;
-	set_selection(start: number, end: number): void;
-	move_cursor_to(position: number, extend: boolean): void;
-	move_cursor_left(extend: boolean): void;
-	move_cursor_right(extend: boolean): void;
-	apply_style_range(
-		start: number,
-		end: number,
-		bold: boolean,
-		italic: boolean,
-		underline: boolean,
-		fontSize?: number,
-		fontFamily?: string,
-		colorRgba?: number[],
-	): void;
-	get_selected_text(): string;
-	clipboard_cut(): void;
-	clipboard_paste(text: string): void;
-	undo(): boolean;
-	redo(): boolean;
-	can_undo(): boolean;
-	can_redo(): boolean;
-	set_now_ms(ms: number): void;
-	break_undo_coalescing(): void;
-	set_coalesce_timeout(ms: number): void;
-	coalesce_timeout(): number;
-	replay_operations_json(operationsJson: string): void;
-	hit_test(screenX: number, screenY: number): number;
-	set_caret_visible(visible: boolean): void;
-	render(): void;
-	free(): void;
-}
+/**
+ * The WASM editor instance type. Uses the auto-generated type definitions
+ * from `wasm-pack build`, ensuring all WASM methods are available with
+ * correct signatures.
+ */
+export type WasmCanvistEditor = GeneratedCanvistEditor;
 
 export interface CanvistWasmModule {
 	default(input?: unknown): Promise<unknown>;
 	CanvistEditor: {
 		create(canvasId: string): WasmCanvistEditor;
+		diff_texts(a: string, b: string): string[];
 	};
 }
 


### PR DESCRIPTION
## Problem

`WasmCanvistEditor` manually declared ~30 of the 568+ WASM methods, causing 586 type errors masked by `--no-check`.

## Fix

- Re-export auto-generated `.d.ts` type from wasm-pack
- Added `diff_texts` static, fixed `colorRgba` type, added missing collab/alignment methods to public API
- `deno check src/editor.ts`: **586 → 0 errors**
- 164/164 Rust tests pass
