### PR TITLE
docs: expand prelude with runtime/operation types and usage example

### DIFF
--- a/.pi/scheduler.json
+++ b/.pi/scheduler.json
@@ -7,13 +7,13 @@
       "kind": "recurring",
       "enabled": true,
       "createdAt": 1774286283770,
-      "nextRunAt": 1774298895125,
+      "nextRunAt": 1774299495125,
       "intervalMs": 600000,
       "expiresAt": 1774545483770,
       "jitterMs": 11355,
-      "runCount": 16,
-      "pending": true,
-      "lastRunAt": 1774298670482,
+      "runCount": 17,
+      "pending": false,
+      "lastRunAt": 1774299119457,
       "lastStatus": "success"
     },
     {

--- a/crates/canvist/src/lib.rs
+++ b/crates/canvist/src/lib.rs
@@ -47,14 +47,44 @@ pub use canvist_wasm as wasm;
 ///
 /// ```
 /// use canvist::prelude::*;
+///
+/// // Document editing.
+/// let mut runtime = EditorRuntime::new(
+///     Document::new(),
+///     Selection::collapsed(Position::zero()),
+///     "user:demo",
+/// );
+/// runtime.handle_event(EditorEvent::TextInsert {
+///     text: "Hello!".to_string(),
+/// }).unwrap();
+///
+/// // Formatting.
+/// runtime.apply_operation(Operation::format(
+///     Selection::range(Position::new(0), Position::new(5)),
+///     Style::new().bold(),
+/// ));
+///
+/// assert_eq!(runtime.document().plain_text(), "Hello!");
 /// ```
 pub mod prelude {
+	// Document model.
+	pub use canvist_core::Color;
 	pub use canvist_core::Document;
+	pub use canvist_core::FontWeight;
 	pub use canvist_core::NodeId;
 	pub use canvist_core::Position;
 	pub use canvist_core::Selection;
 	pub use canvist_core::Style;
+	// Runtime and events.
+	pub use canvist_core::EditorEvent;
+	pub use canvist_core::EditorRuntime;
+	pub use canvist_core::Invalidation;
+	// Operations.
+	pub use canvist_core::operation::Operation;
+	pub use canvist_core::operation::Transaction;
+	// Rendering.
 	pub use canvist_render::Canvas;
+	pub use canvist_render::Rect;
 	pub use canvist_render::Renderer;
 	pub use canvist_render::Viewport;
 }


### PR DESCRIPTION
Expanded the `canvist::prelude` module with commonly-needed types:

- `EditorRuntime`, `EditorEvent`, `Invalidation`
- `Operation`, `Transaction`
- `Color`, `FontWeight`, `Rect`

Added a comprehensive doc example showing the full editing workflow (create runtime → insert text → format → assert).

**181/181 tests**, doc tests pass.
