### PR TITLE
feat: WebSocket collaboration server and cross-machine sync

### DIFF
--- a/.pi/scheduler.json
+++ b/.pi/scheduler.json
@@ -7,13 +7,13 @@
       "kind": "recurring",
       "enabled": true,
       "createdAt": 1774286277211,
-      "nextRunAt": 1774300095323,
+      "nextRunAt": 1774300695323,
       "intervalMs": 600000,
       "expiresAt": 1774545477211,
       "jitterMs": 18112,
-      "runCount": 14,
-      "pending": true,
-      "lastRunAt": 1774299524158,
+      "runCount": 15,
+      "pending": false,
+      "lastRunAt": 1774300508726,
       "lastStatus": "success"
     },
     {
@@ -22,13 +22,13 @@
       "kind": "recurring",
       "enabled": true,
       "createdAt": 1774286283770,
-      "nextRunAt": 1774300695125,
+      "nextRunAt": 1774301295125,
       "intervalMs": 600000,
       "expiresAt": 1774545483770,
       "jitterMs": 11355,
-      "runCount": 19,
+      "runCount": 20,
       "pending": false,
-      "lastRunAt": 1774300110602,
+      "lastRunAt": 1774300695175,
       "lastStatus": "success"
     }
   ]

--- a/packages/canvist/demo/collab-server.ts
+++ b/packages/canvist/demo/collab-server.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env
+/**
+ * canvist collaboration relay server.
+ *
+ * A minimal WebSocket server that relays Yrs CRDT updates between peers.
+ * Each "room" is an independent document. Peers connect to a room via
+ * `ws://host:port/room/<room-id>`.
+ *
+ * Usage:
+ *   deno run --allow-net demo/collab-server.ts
+ *   # or with a custom port:
+ *   PORT=9090 deno run --allow-net demo/collab-server.ts
+ *
+ * Protocol:
+ *   - Client sends: JSON `{ type: "update", data: number[] }` (Yrs binary update as array)
+ *   - Client sends: JSON `{ type: "cursor", offset: number, name: string, color: [r,g,b] }`
+ *   - Server broadcasts to all other peers in the same room.
+ *   - On connect, server sends `{ type: "peer_count", count: number }`.
+ *   - On join/leave, server broadcasts updated peer count.
+ */
+
+interface Peer {
+	socket: WebSocket;
+	name: string;
+	room: string;
+}
+
+const rooms = new Map<string, Set<Peer>>();
+const port = parseInt(Deno.env.get("PORT") || "9001", 10);
+
+function broadcast(room: string, message: string, exclude?: WebSocket) {
+	const peers = rooms.get(room);
+	if (!peers) return;
+	for (const peer of peers) {
+		if (peer.socket !== exclude && peer.socket.readyState === WebSocket.OPEN) {
+			try {
+				peer.socket.send(message);
+			} catch {
+				// Peer disconnected — will be cleaned up on close.
+			}
+		}
+	}
+}
+
+function broadcastPeerCount(room: string) {
+	const count = rooms.get(room)?.size ?? 0;
+	broadcast(room, JSON.stringify({ type: "peer_count", count }));
+}
+
+function handleWebSocket(socket: WebSocket, room: string) {
+	const peerId = `peer-${Math.random().toString(36).slice(2, 8)}`;
+	const peer: Peer = { socket, name: peerId, room };
+
+	// Add to room.
+	if (!rooms.has(room)) {
+		rooms.set(room, new Set());
+	}
+	rooms.get(room)!.add(peer);
+
+	console.log(`[${room}] ${peerId} joined (${rooms.get(room)!.size} peers)`);
+
+	// Send initial peer count.
+	socket.send(JSON.stringify({ type: "peer_count", count: rooms.get(room)!.size }));
+	broadcastPeerCount(room);
+
+	socket.addEventListener("message", (event) => {
+		const data = typeof event.data === "string" ? event.data : "";
+		// Relay to all other peers in the same room.
+		broadcast(room, data, socket);
+	});
+
+	socket.addEventListener("close", () => {
+		rooms.get(room)?.delete(peer);
+		console.log(`[${room}] ${peerId} left (${rooms.get(room)?.size ?? 0} peers)`);
+		if (rooms.get(room)?.size === 0) {
+			rooms.delete(room);
+		} else {
+			broadcastPeerCount(room);
+		}
+	});
+
+	socket.addEventListener("error", (e) => {
+		console.error(`[${room}] ${peerId} error:`, e);
+	});
+}
+
+Deno.serve({ port }, (req) => {
+	const url = new URL(req.url);
+
+	// Health check.
+	if (url.pathname === "/" || url.pathname === "/health") {
+		const totalPeers = [...rooms.values()].reduce((sum, s) => sum + s.size, 0);
+		return new Response(
+			JSON.stringify({
+				status: "ok",
+				rooms: rooms.size,
+				peers: totalPeers,
+			}),
+			{ headers: { "content-type": "application/json" } },
+		);
+	}
+
+	// WebSocket upgrade for room connections.
+	const roomMatch = url.pathname.match(/^\/room\/([a-zA-Z0-9_-]+)$/);
+	if (roomMatch) {
+		const room = roomMatch[1];
+		const upgrade = req.headers.get("upgrade") || "";
+
+		if (upgrade.toLowerCase() !== "websocket") {
+			return new Response(`Room "${room}": connect via WebSocket`, { status: 400 });
+		}
+
+		const { socket, response } = Deno.upgradeWebSocket(req);
+		handleWebSocket(socket, room);
+		return response;
+	}
+
+	return new Response("Not Found", { status: 404 });
+});
+
+console.log(`canvist collab server listening on ws://localhost:${port}`);
+console.log(`Connect to a room: ws://localhost:${port}/room/<room-id>`);

--- a/packages/canvist/demo/collab.html
+++ b/packages/canvist/demo/collab.html
@@ -61,7 +61,12 @@
   </head>
   <body>
     <h1>canvist collab</h1>
-    <p class="subtitle">Real-time collaboration via BroadcastChannel (same browser, multiple tabs)</p>
+    <p class="subtitle">Real-time collaboration — same browser (BroadcastChannel) or cross-machine (WebSocket)</p>
+    <div style="margin-bottom:1rem;display:flex;gap:8px;align-items:center;font-size:0.85rem;">
+      <label>Server: <input id="ws-url" type="text" placeholder="ws://localhost:9001/room/demo" style="padding:4px 8px;border:1px solid #ccc;border-radius:4px;width:280px;" /></label>
+      <button id="ws-connect" style="padding:4px 12px;border:1px solid #ccc;border-radius:4px;cursor:pointer;">Connect</button>
+      <span id="ws-status" style="color:#999;">Not connected</span>
+    </div>
 
     <div class="editor-container">
       <canvas id="editor-canvas" width="800" height="400"></canvas>
@@ -74,9 +79,10 @@
     </div>
 
     <div class="instructions">
-      <strong>How to test:</strong> Open this page in two browser tabs.
-      Type in either tab — edits sync in real-time via the Yrs CRDT.
-      Each tab gets a random color cursor visible in the other tab.
+      <strong>Same-browser:</strong> Open this page in two tabs. Edits sync via BroadcastChannel.<br>
+      <strong>Cross-machine:</strong> Run <code>deno run --allow-net demo/collab-server.ts</code>,
+      then enter <code>ws://localhost:9001/room/demo</code> above and click Connect.
+      Share the URL with others on the same network.
     </div>
 
     <script type="module">
@@ -175,6 +181,99 @@
 
         // Announce ourselves.
         channel.postMessage({ type: "hello", peerId });
+
+        // --- WebSocket for cross-machine sync ---
+        let ws = null;
+        const wsStatus = document.getElementById("ws-status");
+        const wsUrlInput = document.getElementById("ws-url");
+
+        function connectWebSocket() {
+          const url = wsUrlInput.value.trim();
+          if (!url) return;
+          if (ws) { ws.close(); ws = null; }
+
+          try {
+            ws = new WebSocket(url);
+            wsStatus.textContent = "Connecting...";
+            wsStatus.style.color = "#ff9500";
+
+            ws.addEventListener("open", () => {
+              wsStatus.textContent = "Connected ✓";
+              wsStatus.style.color = "#34c759";
+              // Send initial state.
+              scheduleSyncOut();
+            });
+
+            ws.addEventListener("message", (event) => {
+              try {
+                const msg = JSON.parse(event.data);
+                if (msg.type === "sync" && msg.peerId !== peerId) {
+                  const update = new Uint8Array(msg.state);
+                  editor.collab_apply_update(update);
+                  editor.clear_collab_cursors();
+                  editor.add_collab_cursor(
+                    msg.cursor || 0,
+                    msg.peerId,
+                    msg.color[0], msg.color[1], msg.color[2],
+                  );
+                  editor.render();
+                } else if (msg.type === "cursor" && msg.name !== peerId) {
+                  editor.clear_collab_cursors();
+                  editor.add_collab_cursor(msg.offset, msg.name, msg.color[0], msg.color[1], msg.color[2]);
+                  editor.render();
+                } else if (msg.type === "peer_count") {
+                  wsStatus.textContent = `Connected ✓ (${msg.count} peers)`;
+                }
+              } catch {}
+            });
+
+            ws.addEventListener("close", () => {
+              wsStatus.textContent = "Disconnected";
+              wsStatus.style.color = "#999";
+              ws = null;
+            });
+
+            ws.addEventListener("error", () => {
+              wsStatus.textContent = "Connection failed";
+              wsStatus.style.color = "#ff3b30";
+            });
+          } catch {
+            wsStatus.textContent = "Invalid URL";
+            wsStatus.style.color = "#ff3b30";
+          }
+        }
+
+        document.getElementById("ws-connect").addEventListener("click", connectWebSocket);
+        wsUrlInput.addEventListener("keydown", (e) => {
+          if (e.key === "Enter") connectWebSocket();
+        });
+
+        // Override scheduleSyncOut to also send via WebSocket.
+        const originalScheduleSyncOut = scheduleSyncOut;
+        scheduleSyncOut = function() {
+          // BroadcastChannel sync (same browser).
+          if (syncTimer) clearTimeout(syncTimer);
+          syncTimer = setTimeout(() => {
+            try {
+              const state = editor.collab_encode_state();
+              const msg = {
+                type: "sync",
+                peerId,
+                state: Array.from(state),
+                cursor: cursorOffset,
+                color: peerColor,
+              };
+              channel.postMessage(msg);
+              // Also send via WebSocket if connected.
+              if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify(msg));
+              }
+              document.getElementById("status-sync").textContent = "Synced";
+            } catch (e) {
+              console.error("sync error:", e);
+            }
+          }, 50);
+        };
 
         // --- Input handling (simplified version of the main demo) ---
         const textarea = document.createElement("textarea");


### PR DESCRIPTION
## Collab Server (`demo/collab-server.ts`)

Minimal Deno WebSocket relay for Yrs CRDT updates:
- Room-based: `ws://host:port/room/<room-id>`
- Broadcasts to all peers in room
- Health endpoint with room/peer counts
- `deno run --allow-net --allow-env demo/collab-server.ts`

## Demo Updates

- WebSocket URL input + Connect button
- Dual transport: BroadcastChannel (same browser) + WebSocket (cross-machine)
- Connection status with peer count

**186/186 tests pass**
